### PR TITLE
simplify container dependencies in docker-compose in preparation for generating helm charts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 services:
   db:
     container_name: db
-    platform: linux/x86_64
     image: mysql
     hostname: backend-service-db
     build:
@@ -20,7 +19,7 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     healthcheck:
       test: mysql -h backend-service-db -P 3306 --user=$$MYSQL_USER --password=$$MYSQL_PASSWORD -e 'SHOW DATABASES;'
-      start_period: 10s
+      # start_period: 10s # change in docker-compose syntax support
       interval: 2s
       timeout: 5s
       retries: 20
@@ -30,8 +29,7 @@ services:
       dockerfile: backend-service/Dockerfile
     hostname: backend-service
     depends_on:
-      db:
-        condition: service_healthy
+      - db
     ports:
       - "9090:9090" # http
   api:


### PR DESCRIPTION
quite a few things changed in docker-compose from v2 to v3
now, there's some more v2 concepts being reintroduced in v3.9

this change compose spec is causing issues in using tools like `kustomize` that can help in generating k8s manifests from docker-compose

the goal of this PR is to simplify the file to be able to use such tools to generate helm charts.

see https://stackoverflow.com/questions/71060072/docker-compose-depends-on-with-condition-invalid-type-should-be-an-array