### PR TITLE
Adds a volume for mysql data to be persisted. Fix schema mounting.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
 version: '3'
+
+volumes:
+  mysql-volume:
+
 services:
   db:
     container_name: db
@@ -11,7 +15,8 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - ./backend-service/cmd/server/storage:/docker-entrypoint-initdb.d
+      - ./backend-service/cmd/server/storage/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+      - mysql-volume:/var/lib/mysql
     environment:
       MYSQL_USER: admin
       MYSQL_PASSWORD: password


### PR DESCRIPTION
Adds a volume for mysql data so it doesn't need to initialize from scratch all the time. This makes the startup time faster.

Fixes mounting the Dockerfile into the initdb entrypoint.
